### PR TITLE
Disable http client metrics, they bloat metrics

### DIFF
--- a/src/main/java/net/ripe/rpki/rsyncit/RsyncitApplication.java
+++ b/src/main/java/net/ripe/rpki/rsyncit/RsyncitApplication.java
@@ -18,6 +18,7 @@ public class RsyncitApplication {
         Properties properties = new Properties();
         properties.put("spring.codec.max-in-memory-size", "1GB");
         properties.put("management.endpoints.web.exposure.include", "info,prometheus,health");
+        properties.put("management.metrics.enable.http.client.requests", "false");
         application.setDefaultProperties(properties);
         application.run(args);
     }


### PR DESCRIPTION
It creates new tag value for every new snapshot URL so it bloating metrics
```
http_client_requests_seconds_max{client_name="rrdp.ripe.net",error="none",exception="none",method="GET",outcome="SUCCESS",status="200",uri="/f351ea8a-62f5-4138-ad36-e93aa102fa88/39483/snapshot-ffd032beb276ee833af3ce693f506bbbc7b57dac71b946964dad8f27612baa57.xml",} 0.0
http_client_requests_seconds_max{client_name="rrdp.ripe.net",error="none",exception="none",method="GET",outcome="SUCCESS",status="200",uri="/f351ea8a-62f5-4138-ad36-e93aa102fa88/39360/snapshot-3859b8edde4bc06ee33cae2ab52ccaecc1fd1ac59e56b9b9448b6e8d85510e36.xml",} 0.0
http_client_requests_seconds_max{client_name="rrdp.ripe.net",error="none",exception="none",method="GET",outcome="SUCCESS",status="200",uri="/f351ea8a-62f5-4138-ad36-e93aa102fa88/39426/snapshot-b70b30ed711f81bb84f1fe62ac728d280acfa3c2432640bc8187b4ef81020af6.xml",} 0.0
```