### PR TITLE
rsync may change time behaviour => do not use hash in time

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,19 +1,17 @@
 plugins {
     id 'java'
-    id 'io.freefair.lombok' version '8.0.1'
-    id 'org.springframework.boot' version '3.0.5'
+    id 'io.freefair.lombok' version '8.4'
+    id 'org.springframework.boot' version '3.1.5'
     id 'com.gorylenko.gradle-git-properties' version '2.4.1'
     id 'org.sonarqube' version '3.5.0.2730'
-    id 'com.google.cloud.tools.jib' version '3.3.1'
+    id 'com.google.cloud.tools.jib' version '3.4.0'
 }
 
 apply plugin: 'java'
 apply plugin: 'io.spring.dependency-management'
 
-apply from: "dependencies.gradle"
-
 group = 'net.ripe.rpki'
-version = '0.0.1-SNAPSHOT'
+version = '0.0.2-SNAPSHOT'
 
 repositories {
     mavenCentral()
@@ -31,9 +29,8 @@ dependencies {
     implementation 'io.micrometer:micrometer-registry-prometheus'
 
     implementation 'com.google.guava:guava:31.1-jre'
-    implementation 'org.apache.commons:commons-lang3:3.0'
 
-    implementation "net.ripe.rpki:rpki-commons:$rpki_commons_version"
+    implementation "net.ripe.rpki:rpki-commons:1.36"
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,4 +1,0 @@
-ext {
-    rpki_commons_version = '1.32'
-
-}


### PR DESCRIPTION
https://github.com/WayneD/rsync/commit/839dbff2aaf0277471e1986a3cd0f869e0bdda24

```
Add support for comparing nanoseconds on the receiver.
This patch adds the ability to specify --modify-window=-1 (aka -@-1) to
ask rsync to compare files with the full nanosecond timestamps.  The
default is still -@0 for the moment, which ignores nanoseconds in time
comparisons.  Changing the default to -1 would cause a copy from ext4 to
ext3 to constantly compare as different, or a copy there and back again
to do a full copy as it zeroed all the nanosecond times.  Such a change
might be too much of a functional difference for things like backup
solutions to handle without a warning period.  The current plan is to
support nanosecond comparisons for those that want them, and possibly
change the default window value from 0 to -1 at some point in the
future.
```