### PR TITLE
Prevent concurrent syncs

### DIFF
--- a/src/main/java/net/ripe/rpki/rsyncit/rrdp/RRDPFetcherMetrics.java
+++ b/src/main/java/net/ripe/rpki/rsyncit/rrdp/RRDPFetcherMetrics.java
@@ -14,6 +14,7 @@ public final class RRDPFetcherMetrics {
     private final Counter timeoutUpdates;
     private final Counter rejectedUpdates;
     private final Counter objectFailures;
+    private final Counter tooSlow;
 
     public final Timer objectConstructionTimer;
 
@@ -22,14 +23,16 @@ public final class RRDPFetcherMetrics {
         failedUpdates = buildCounter("failed", meterRegistry);
         timeoutUpdates = buildCounter("timeout", meterRegistry);
         rejectedUpdates = buildCounter("rejected", meterRegistry);
+        tooSlow = buildCounter("slow", meterRegistry);
+
         objectFailures = Counter.builder("rsyncit.fetcher.objects")
-            .description("Metrics on objects")
-            .tag("status", "failure")
-            .register(meterRegistry);
+                .description("Metrics on objects")
+                .tag("status", "failure")
+                .register(meterRegistry);
 
         Gauge.builder("rsyncit.fetcher.rrdp.serial", rrdpSerial::get)
-            .description("Serial of the RRDP notification.xml at the given URL")
-            .register(meterRegistry);
+                .description("Serial of the RRDP notification.xml at the given URL")
+                .register(meterRegistry);
 
         objectConstructionTimer = Timer.builder("rsyncit.fetcher.parsing")
                 .description("Time spent parsing objects for the last run")
@@ -49,6 +52,10 @@ public final class RRDPFetcherMetrics {
         this.timeoutUpdates.increment();
     }
 
+    public void tooSlow() {
+        this.tooSlow.increment();
+    }
+
     public void badObject() {
         this.objectFailures.increment();
     }
@@ -59,8 +66,8 @@ public final class RRDPFetcherMetrics {
 
     private static Counter buildCounter(String statusTag, MeterRegistry registry) {
         return Counter.builder("rsyncit.fetcher.updated")
-            .description("Number of fetches")
-            .tag("status", statusTag)
-            .register(registry);
+                .description("Number of fetches")
+                .tag("status", statusTag)
+                .register(registry);
     }
 }

--- a/src/main/java/net/ripe/rpki/rsyncit/service/SyncService.java
+++ b/src/main/java/net/ripe/rpki/rsyncit/service/SyncService.java
@@ -40,7 +40,6 @@ public class SyncService {
     }
 
     public void sync() {
-        // Do not mutate isRunning here, do it inside the try block
         if (isRunning) {
             log.info("Sync is already running, skipping this run. Most likely it means that the system is abnormally slow.");
             metrics.tooSlow();

--- a/src/main/java/net/ripe/rpki/rsyncit/service/SyncService.java
+++ b/src/main/java/net/ripe/rpki/rsyncit/service/SyncService.java
@@ -57,7 +57,7 @@ public class SyncService {
         }
     }
 
-    private synchronized void doSync() {
+    private void doSync() {
         var config = appConfig.getConfig();
         var rrdpFetcher = new RrdpFetcher(config, webClient, state, metrics);
 

--- a/src/main/java/net/ripe/rpki/rsyncit/service/SyncService.java
+++ b/src/main/java/net/ripe/rpki/rsyncit/service/SyncService.java
@@ -44,9 +44,7 @@ public class SyncService {
         if (isRunning) {
             log.info("Sync is already running, skipping this run. Most likely it means that the system is abnormally slow.");
             metrics.tooSlow();
-            return;
-        }
-        if (!isRunning) {
+        } else {
             try {
                 isRunning = true;
                 doSync();

--- a/src/main/java/net/ripe/rpki/rsyncit/service/SyncService.java
+++ b/src/main/java/net/ripe/rpki/rsyncit/service/SyncService.java
@@ -41,13 +41,12 @@ public class SyncService {
 
     public void sync() {
         // Do not mutate isRunning here, do it inside the try block
-        boolean shouldRun = !isRunning;
         if (isRunning) {
             log.info("Sync is already running, skipping this run. Most likely it means that the system is abnormally slow.");
             metrics.tooSlow();
             return;
         }
-        if (shouldRun) {
+        if (!isRunning) {
             try {
                 isRunning = true;
                 doSync();


### PR DESCRIPTION
This one is to skip concurrent syncs. Skipping a sync instead of blocking and waiting is intentional here because we still want two (multiple) instances syncing at more or less the same time based on cron mask. Blocking will more likely cause serials on these instances to diverge (I guess).